### PR TITLE
Initialize Undebugger manually

### DIFF
--- a/Runtime/Scripts/UndebuggerRoot.cs
+++ b/Runtime/Scripts/UndebuggerRoot.cs
@@ -2,25 +2,36 @@
 #define UNDEBUGGER_ENABLED
 #endif
 
+using System.Runtime.CompilerServices;
 using UnityEngine;
 
 namespace Undebugger
 {
-    internal static class UndebuggerRoot
+    public static class UndebuggerRoot
     {
         public const string Version = "1.0.0";
 
 #if UNDEBUGGER_ENABLED
 
-        public static readonly GameObject Object;
-        public static readonly Transform Transform;
+        public static GameObject Object;
+        public static Transform Transform;
 
-        static UndebuggerRoot()
+        public static void Initialize()
         {
+            GameObject.Destroy(UndebuggerRoot.Object);
+            UndebuggerRoot.Transform = null;
+            
             Object = new GameObject("Undebugger");
             Object.hideFlags = HideFlags.NotEditable;
             Transform = Object.transform;
             GameObject.DontDestroyOnLoad(Object);
+        }
+
+        public static void Destroy()
+        {
+            GameObject.Destroy(UndebuggerRoot.Object);
+            UndebuggerRoot.Transform = null;
+
         }
 
         public static T CreateServiceInstance<T>(string name)


### PR DESCRIPTION
If Unity is setup not to clear static fields the plugin stops working from the second Playmode launch.

![image](https://github.com/user-attachments/assets/63a06bca-5f4c-429f-9233-275b5c8fdced)

Had to initialize it manually
